### PR TITLE
Fix setting of default affiliation (or falling back on 'member') on node...

### DIFF
--- a/src/main/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/set/SubscribeSet.java
+++ b/src/main/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/set/SubscribeSet.java
@@ -126,8 +126,8 @@ public class SubscribeSet extends PubSubElementProcessorAbstract {
 				return;
 			}
 
-			Affiliations defaultAffiliation = null;
-			Subscriptions defaultSubscription = null;
+			Affiliations defaultAffiliation = Affiliations.member;
+			Subscriptions defaultSubscription = Subscriptions.none;
 
 			if (!possibleExistingSubscription.in(Subscriptions.none) && 
 					!possibleExistingAffiliation.in(Affiliations.none)) {
@@ -138,16 +138,17 @@ public class SubscribeSet extends PubSubElementProcessorAbstract {
 				defaultSubscription = possibleExistingSubscription;
 			} else {
 				try {
-					String nodeDefAffiliation = nodeConf.get(Conf.DEFAULT_AFFILIATION);
-					LOGGER.debug("Node default affiliation: '" + nodeDefAffiliation + "'");
-					defaultAffiliation = Affiliations.createFromString(nodeDefAffiliation);
+					String nodeDefaultAffiliation = nodeConf.get(Conf.DEFAULT_AFFILIATION);
+					LOGGER.debug("Node default affiliation: '" + nodeDefaultAffiliation + "'");
+					if (!Affiliations.none.equals(Affiliations.createFromString(nodeDefaultAffiliation))) {
+						defaultAffiliation = Affiliations.createFromString(nodeDefaultAffiliation);
+					}
 				} catch (NullPointerException e) {
 					LOGGER.error("Could not create affiliation.", e);
 					defaultAffiliation = Affiliations.member;
 				}
 				defaultSubscription = Subscriptions.subscribed;
 				String accessModel = nodeConf.get(Conf.ACCESS_MODEL);
-
 				if ((null == accessModel)
 						|| (true == accessModel.equals(AccessModels.authorize
 								.toString()))


### PR DESCRIPTION
... subscriptions

Fixes #121

Currently it looks like all new subscriptions are getting an affiliation of 'none' regardless of the default affiliation configuration, this isn't good.

Added tests for this. Should the configuration value not exist then there is a fallback to 'member' now.

Once this gets merged I'd suggest deploying the latest version with this included.

@imaginator @abmargb
