### PR TITLE
Explicitly set the timezone to UTC in maven config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.5</version>
                     <configuration>
+                      <argLine>-Duser.timezone=UTC</argLine>
                         <skipTests>false</skipTests>
  					<testFailureIgnore>true</testFailureIgnore>
                         <forkMode>once</forkMode>


### PR DESCRIPTION
This prevents AtomEntryTest.missingUpdatedElementHasValueAdded() failing
when the host is running in a different timezone.
