### PR TITLE
Use database 'listener' to speed up discovery (D.R.Y.!)

### DIFF
--- a/src/main/java/org/buddycloud/channelserver/ChannelsEngine.java
+++ b/src/main/java/org/buddycloud/channelserver/ChannelsEngine.java
@@ -112,7 +112,7 @@ public class ChannelsEngine implements Component {
 		channelManagerFactory = new ChannelManagerFactoryImpl(configuration,
 				nodeStoreFactory);
 		federatedQueueManager = new FederatedQueueManager(this,
-				configuration);
+				configuration, channelManagerFactory);
 		onlineUsers = new OnlineResourceManager(configuration);
 	}
 

--- a/src/test/resources/stanzas/iq/federated/request.stanza
+++ b/src/test/resources/stanzas/iq/federated/request.stanza
@@ -1,0 +1,9 @@
+<iq type="get"
+    from="francisco@shakespeare.lit/barracks"
+    to="channels.shakespeare.lit"
+    id="items1">
+   <pubsub xmlns="http://jabber.org/protocol/pubsub">
+      <items node="/user/romeo@montague.lit/posts"/>
+      <actor xmlns="http://buddycloud.org/v1">francisco@shakespeare.lit</actor>
+   </pubsub>
+</iq>


### PR DESCRIPTION
We've already discovered the listener for a particular domain in the past, so why are we re-performing discovery each time the server starts afresh?

Even if a user changed the subdomain of their channel server there's no update mechanism at present and they wouldn't get pushed updates.

In the future we could perform discovery and update listeners for everyone at the same domain, but for now this seems like a sensible inclusion.
