### PR TITLE
Allow node creation with default configuration (i.e. no <configure/>)

### DIFF
--- a/src/main/java/org/buddycloud/channelserver/channel/node/configuration/Helper.java
+++ b/src/main/java/org/buddycloud/channelserver/channel/node/configuration/Helper.java
@@ -1,6 +1,7 @@
 package org.buddycloud.channelserver.channel.node.configuration;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
@@ -123,8 +124,18 @@ public class Helper {
 	}
 
 	private List<FormField> getConfigurationValues(IQ request) {
-		Element element = request.getElement().element("pubsub")
-				.element("configure").element("x");
+		Element configure = request.getElement().element("pubsub").element("configure");
+		
+		if(configure == null) {
+			return Collections.emptyList();
+		}
+		
+		Element element = configure.element("x");
+
+		if(element == null) {
+			return Collections.emptyList();
+		}
+		
 		DataForm dataForm = new DataForm(element);
 		List<FormField> fields = dataForm.getFields();
 		return fields;

--- a/src/test/java/org/buddycloud/channelserver/channel/node/configuration/HelperTest.java
+++ b/src/test/java/org/buddycloud/channelserver/channel/node/configuration/HelperTest.java
@@ -48,15 +48,6 @@ public class HelperTest extends IQTestHandler {
 		parser.setFieldFactory(new Factory());
 	}
 
-	@Test(expected = NodeConfigurationException.class)
-	public void testPassingPacketWhichDoesntContainConfigureElementThrowsException() {
-		Element iq = new DOMElement("iq");
-		iq.addElement("pubsub", JabberPubsub.NS_PUBSUB_OWNER);
-		IQ request = new IQ(iq);
-
-		parser.parse(request);
-	}
-
 	@Test
 	public void testNotProvidingAnyConfigurationFieldsReturnsOnlyLastUpdatedDate()
 			throws NodeStoreException {
@@ -381,5 +372,36 @@ public class HelperTest extends IQTestHandler {
         Assert.assertEquals(Affiliation.DEFAULT_VALUE, configurationValues.get(Affiliation.FIELD_NAME));
         Assert.assertNotNull(configurationValues.get(LastUpdatedDate.FIELD_NAME));
         
+	}
+	
+	/**
+	 * We expect this to <b>not</b> throw a {@link NodeConfigurationException}
+	 * 
+	 * @see https://github.com/buddycloud/buddycloud-server-java/issues/200
+	 */
+	@Test
+	public void testParseIQWithMissingForm() {
+		Element iq = new DOMElement("iq");
+		Element pubsub = iq.addElement("pubsub");
+		pubsub.addAttribute("xmlns", JabberPubsub.NS_PUBSUB_OWNER);
+		pubsub.addElement("configure");
+		
+		IQ request = new IQ(iq);
+		parser.parse(request);
+	}
+	
+	/**
+	 * We expect this to <b>not</b> throw a {@link NodeConfigurationException}
+	 * 
+	 * @see https://github.com/buddycloud/buddycloud-server-java/issues/200
+	 */
+	@Test
+	public void testParseIQWithMissingConfigure() {
+		Element iq = new DOMElement("iq");
+		Element pubsub = iq.addElement("pubsub");
+		pubsub.addAttribute("xmlns", JabberPubsub.NS_PUBSUB_OWNER);
+		
+		IQ request = new IQ(iq);
+		parser.parse(request);
 	}
 }


### PR DESCRIPTION
Brings the server more in line with XEP-0060, and fixes #200 by allowing node creation without specifying a configure element.
