### PR TITLE
Send RSM element when there are no replies

### DIFF
--- a/src/main/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/get/RepliesGet.java
+++ b/src/main/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/get/RepliesGet.java
@@ -87,14 +87,15 @@ public class RepliesGet extends PubSubElementProcessorAbstract {
     }
 
     protected void addRsmElement() throws NodeStoreException {
-        if (null == firstItemId) {
-            return;
-        }
+
         Element rsm = pubsub.addElement(XMLConstants.SET_ELEM);
         rsm.addNamespace("", NS_RSM);
-        rsm.addElement("first").setText(firstItemId);
-        rsm.addElement("last").setText(lastItemId);
-        rsm.addElement("count").setText(String.valueOf(channelManager.getCountNodeItemReplies(node, parentId)));
+        if (null != firstItemId) {
+            rsm.addElement("first").setText(firstItemId);
+            rsm.addElement("last").setText(lastItemId);
+        }
+        rsm.addElement("count").setText(
+            String.valueOf(channelManager.getCountNodeItemReplies(node, parentId)));
     }
 
     private void addReplies() throws NodeStoreException {


### PR DESCRIPTION
For item replies if there were no results then the RSM element wasn't being generated and sent. This fixes that problem. @mrflix will be happy.