### PR TITLE
Implement RSM <before/> for item replies retrieval

### DIFF
--- a/src/main/java/org/buddycloud/channelserver/channel/ChannelManagerImpl.java
+++ b/src/main/java/org/buddycloud/channelserver/channel/ChannelManagerImpl.java
@@ -125,8 +125,8 @@ public class ChannelManagerImpl implements ChannelManager {
 
   @Override
   public ClosableIteratorImpl<NodeItem> getNodeItemReplies(String nodeId, String itemId,
-      String afterItemId, int limit) throws NodeStoreException {
-    return nodeStore.getNodeItemReplies(nodeId, itemId, afterItemId, limit);
+      String afterItemId, boolean after, int limit) throws NodeStoreException {
+    return nodeStore.getNodeItemReplies(nodeId, itemId, afterItemId, after, limit);
   }
 
   @Override

--- a/src/main/java/org/buddycloud/channelserver/db/NodeStore.java
+++ b/src/main/java/org/buddycloud/channelserver/db/NodeStore.java
@@ -268,7 +268,7 @@ public interface NodeStore {
      * @return
      * @throws NodeStoreException
      */
-    ClosableIteratorImpl<NodeItem> getNodeItemReplies(String nodeId, String itemId, String afterItemId, int limit) throws NodeStoreException;
+    ClosableIteratorImpl<NodeItem> getNodeItemReplies(String nodeId, String itemId, String rsmItemId, boolean after, int limit) throws NodeStoreException;
 
     /**
      * Get a count of the number of replies to an item

--- a/src/main/java/org/buddycloud/channelserver/db/jdbc/JDBCNodeStore.java
+++ b/src/main/java/org/buddycloud/channelserver/db/jdbc/JDBCNodeStore.java
@@ -1181,7 +1181,6 @@ public class JDBCNodeStore implements NodeStore {
             if (null != rsmItem) {
                 since = getNodeItem(nodeId, rsmItem).getUpdated();
             }
-
             String query = dialect.selectItemReplies()
                 .replace("%beforeAfter%", afterReplacement);
             

--- a/src/main/java/org/buddycloud/channelserver/db/jdbc/JDBCNodeStore.java
+++ b/src/main/java/org/buddycloud/channelserver/db/jdbc/JDBCNodeStore.java
@@ -1167,16 +1167,24 @@ public class JDBCNodeStore implements NodeStore {
     }
 
     @Override
-    public ClosableIteratorImpl<NodeItem> getNodeItemReplies(String nodeId, String itemId, String afterItemId, int limit) throws NodeStoreException {
+    public ClosableIteratorImpl<NodeItem> getNodeItemReplies(String nodeId, String itemId, String rsmItem, boolean after, int limit) throws NodeStoreException {
         PreparedStatement stmt = null;
 
         try {
-            Date since = new Date(0);
-            if (null != afterItemId) {
-                since = getNodeItem(nodeId, afterItemId).getUpdated();
+            Date since = new Date();
+            String afterReplacement = "<";
+            if (after) {
+              since = new Date(0);
+              afterReplacement = ">";
+            }
+            
+            if (null != rsmItem) {
+                since = getNodeItem(nodeId, rsmItem).getUpdated();
             }
 
-            String query = dialect.selectItemReplies();
+            String query = dialect.selectItemReplies()
+                .replace("%beforeAfter%", afterReplacement);
+            
             if (-1 != limit) {
                 query += " LIMIT ?";
             }

--- a/src/main/java/org/buddycloud/channelserver/db/jdbc/dialect/Sql92NodeStoreDialect.java
+++ b/src/main/java/org/buddycloud/channelserver/db/jdbc/dialect/Sql92NodeStoreDialect.java
@@ -133,7 +133,7 @@ public class Sql92NodeStoreDialect implements NodeStoreSQLDialect {
     private static final String COUNT_ITEMS_FOR_NODE = "SELECT COUNT(*)" + " FROM \"items\" WHERE \"node\" = ? %parentOnly%;";
 
     private static final String SELECT_ITEM_REPLIES = "" + "SELECT \"id\", \"node\", \"xml\", \"updated\", \"in_reply_to\", \"created\" "
-            + "FROM \"items\" WHERE \"node\" = ? AND \"in_reply_to\" LIKE ? " + "AND \"updated\" > ? ORDER BY \"updated\" DESC";
+            + "FROM \"items\" WHERE \"node\" = ? AND \"in_reply_to\" LIKE ? " + "AND \"updated\" %beforeAfter% ? ORDER BY \"updated\" DESC";
 
     private static final String SELECT_ITEM_THREAD = "" + "SELECT \"id\", \"node\", \"xml\", \"updated\", \"in_reply_to\", \"created\" "
             + "FROM \"items\" WHERE \"node\" = ? " + "AND (\"in_reply_to\" LIKE ? OR \"id\" = ?) " + "AND \"updated\" > ? ORDER BY \"updated\" DESC";

--- a/src/main/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/PubSubElementProcessorAbstract.java
+++ b/src/main/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/PubSubElementProcessorAbstract.java
@@ -47,6 +47,7 @@ public abstract class PubSubElementProcessorAbstract implements PubSubElementPro
     // RSM details
     protected int maxResults = -1;
     protected String afterItemId = null;
+    protected String beforeItemId;
 
     protected Element resultSetManagement;
     protected String firstItem;
@@ -267,8 +268,12 @@ public abstract class PubSubElementProcessorAbstract implements PubSubElementPro
             maxResults = Integer.parseInt(max.getTextTrim());
         }
         Element after;
+        Element before;
         if (null != (after = rsmElement.element("after"))) {
             afterItemId = after.getTextTrim();
+        }
+        if (null != (before = rsmElement.element("before"))) {
+            beforeItemId = before.getTextTrim();
         }
 
         return true;

--- a/src/main/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/get/RepliesGet.java
+++ b/src/main/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/get/RepliesGet.java
@@ -99,7 +99,8 @@ public class RepliesGet extends PubSubElementProcessorAbstract {
 
     private void addReplies() throws NodeStoreException {
 
-        CloseableIterator<NodeItem> items = channelManager.getNodeItemReplies(node, parentId, afterItemId, maxResults);
+        boolean after = true;
+        CloseableIterator<NodeItem> items = channelManager.getNodeItemReplies(node, parentId, afterItemId, after, maxResults);
         NodeItem item;
         Element entry;
         Element itemElement;

--- a/src/main/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/get/RepliesGet.java
+++ b/src/main/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/get/RepliesGet.java
@@ -99,7 +99,13 @@ public class RepliesGet extends PubSubElementProcessorAbstract {
 
     private void addReplies() throws NodeStoreException {
 
+        String rsmItem = afterItemId;
         boolean after = true;
+        if (null != beforeItemId) {
+          rsmItem = beforeItemId;
+          after = false;
+        }
+        
         CloseableIterator<NodeItem> items = channelManager.getNodeItemReplies(node, parentId, afterItemId, after, maxResults);
         NodeItem item;
         Element entry;

--- a/src/main/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/get/RepliesGet.java
+++ b/src/main/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/get/RepliesGet.java
@@ -106,7 +106,7 @@ public class RepliesGet extends PubSubElementProcessorAbstract {
           after = false;
         }
         
-        CloseableIterator<NodeItem> items = channelManager.getNodeItemReplies(node, parentId, afterItemId, after, maxResults);
+        CloseableIterator<NodeItem> items = channelManager.getNodeItemReplies(node, parentId, rsmItem, after, maxResults);
         NodeItem item;
         Element entry;
         Element itemElement;

--- a/src/main/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/set/ItemDelete.java
+++ b/src/main/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/set/ItemDelete.java
@@ -95,7 +95,7 @@ public class ItemDelete extends PubSubElementProcessorAbstract {
         if (null != nodeItem.getInReplyTo()) {
             return;
         }
-        ClosableIteratorImpl<NodeItem> replies = channelManager.getNodeItemReplies(node, itemId.getItemID(), null, -1);
+        ClosableIteratorImpl<NodeItem> replies = channelManager.getNodeItemReplies(node, itemId.getItemID(), null, true, -1);
         NodeItem reply = null;
         while (replies.hasNext()) {
             reply = replies.next();

--- a/src/test/java/org/buddycloud/channelserver/db/jdbc/JDBCNodeStoreTest.java
+++ b/src/test/java/org/buddycloud/channelserver/db/jdbc/JDBCNodeStoreTest.java
@@ -391,7 +391,7 @@ public class JDBCNodeStoreTest extends JDBCNodeStoreAbstract {
         store.addNodeItem(testItem);
 
         ClosableIteratorImpl<NodeItem> items = store.getNodeItemReplies(
-                TEST_SERVER1_NODE1_ID, "a5", null, -1);
+                TEST_SERVER1_NODE1_ID, "a5", null, true, -1);
 
         int count = 0;
         NodeItem item = null;
@@ -421,7 +421,7 @@ public class JDBCNodeStoreTest extends JDBCNodeStoreAbstract {
         store.addNodeItem(testItem4);
 
         ClosableIteratorImpl<NodeItem> items = store.getNodeItemReplies(
-                TEST_SERVER1_NODE1_ID, "a5", "a7", 2);
+                TEST_SERVER1_NODE1_ID, "a5", "a7", true, 2);
 
         int count = 0;
         ArrayList<NodeItem> itemsResult = new ArrayList<NodeItem>();

--- a/src/test/java/org/buddycloud/channelserver/db/jdbc/JDBCNodeStoreTest.java
+++ b/src/test/java/org/buddycloud/channelserver/db/jdbc/JDBCNodeStoreTest.java
@@ -436,6 +436,41 @@ public class JDBCNodeStoreTest extends JDBCNodeStoreAbstract {
     }
 
     @Test
+    public void canGetItemRepliesWithResultSetManagementPagingBackwards() throws Exception {
+
+        dbTester.loadData("node_1");
+        NodeItem testItem1 = new NodeItemImpl(TEST_SERVER1_NODE1_ID, "a6",
+                new Date(), "<entry>payload</entry>", "a5", new Date());
+        Thread.sleep(100);
+        NodeItem testItem2 = new NodeItemImpl(TEST_SERVER1_NODE1_ID, "a7",
+                new Date(), "<entry>payload</entry>", "a5", new Date());
+        Thread.sleep(100);
+        NodeItem testItem3 = new NodeItemImpl(TEST_SERVER1_NODE1_ID, "a8",
+                new Date(), "<entry>payload</entry>", "a5", new Date());
+        Thread.sleep(100);
+        NodeItem testItem4 = new NodeItemImpl(TEST_SERVER1_NODE1_ID, "a9",
+                new Date(), "<entry>payload</entry>", "/full-node-item-id-ref/a5", new Date());
+        store.addNodeItem(testItem1);
+        store.addNodeItem(testItem2);
+        store.addNodeItem(testItem3);
+        store.addNodeItem(testItem4);
+        
+        ClosableIteratorImpl<NodeItem> items = store.getNodeItemReplies(
+                TEST_SERVER1_NODE1_ID, "a5", "a8", false, 4);
+
+        int count = 0;
+        ArrayList<NodeItem> itemsResult = new ArrayList<NodeItem>();
+        while (items.hasNext()) {
+            ++count;
+            itemsResult.add(items.next());
+
+        }
+        assertEquals(2, count);
+        assertSameNodeItem(itemsResult.get(0), testItem1);
+        assertSameNodeItem(itemsResult.get(1), testItem2);
+    }
+
+    @Test
     public void canGetCountOfItemReplies() throws Exception {
         dbTester.loadData("node_1");
         NodeItem testItem = new NodeItemImpl(TEST_SERVER1_NODE1_ID, "a6",

--- a/src/test/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/get/RepliesGetTest.java
+++ b/src/test/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/get/RepliesGetTest.java
@@ -160,7 +160,7 @@ public class RepliesGetTest extends IQTestHandler {
     @Test
     public void testNoRepliesReturnsEmptyStanza() throws Exception {
 
-        Mockito.when(channelManager.getNodeItemReplies(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt())).thenReturn(
+        Mockito.when(channelManager.getNodeItemReplies(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.eq(true), Mockito.anyInt())).thenReturn(
                 new ClosableIteratorImpl<NodeItem>(new ArrayList<NodeItem>().iterator()));
 
         repliesGet.process(element, jid, request, null);
@@ -178,7 +178,7 @@ public class RepliesGetTest extends IQTestHandler {
         expectedResults.add(new NodeItemImpl(TEST_NODE, "1", new Date(), "<entry>value1</entry>"));
         expectedResults.add(new NodeItemImpl(TEST_NODE, "2", new Date(), "<entry>value2</entry>"));
 
-        Mockito.when(channelManager.getNodeItemReplies(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt())).thenReturn(
+        Mockito.when(channelManager.getNodeItemReplies(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.eq(true), Mockito.anyInt())).thenReturn(
                 new ClosableIteratorImpl<NodeItem>(expectedResults.iterator()));
 
         repliesGet.process(element, jid, request, null);
@@ -198,7 +198,7 @@ public class RepliesGetTest extends IQTestHandler {
         expectedResults.add(new NodeItemImpl(TEST_NODE, "1", new Date(), "<entry>value1</entry>"));
         expectedResults.add(new NodeItemImpl(TEST_NODE, "2", new Date(), "<entry>value2"));
 
-        Mockito.when(channelManager.getNodeItemReplies(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt())).thenReturn(
+        Mockito.when(channelManager.getNodeItemReplies(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.eq(true), Mockito.anyInt())).thenReturn(
                 new ClosableIteratorImpl<NodeItem>(expectedResults.iterator()));
 
         repliesGet.process(element, jid, request, null);
@@ -225,7 +225,7 @@ public class RepliesGetTest extends IQTestHandler {
         expectedResults.add(new NodeItemImpl(TEST_NODE, "3", new Date(), "<entry>value3</entry>"));
         expectedResults.add(new NodeItemImpl(TEST_NODE, "4", new Date(), "<entry>value4</entry>"));
 
-        Mockito.when(channelManager.getNodeItemReplies(Mockito.anyString(), Mockito.anyString(), Mockito.eq("1"), Mockito.eq(4))).thenReturn(
+        Mockito.when(channelManager.getNodeItemReplies(Mockito.anyString(), Mockito.anyString(), Mockito.eq("1"), Mockito.eq(true), Mockito.eq(4))).thenReturn(
                 new ClosableIteratorImpl<NodeItem>(expectedResults.iterator()));
 
         repliesGet.process(element, jid, request, null);

--- a/src/test/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/set/ItemDeleteTest.java
+++ b/src/test/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/set/ItemDeleteTest.java
@@ -396,7 +396,7 @@ public class ItemDeleteTest extends IQTestHandler {
         Mockito.doThrow(Exception.class)
                 .when(channelManager)
                 .getNodeItemReplies(Mockito.anyString(), Mockito.anyString(),
-                        Mockito.anyString(), Mockito.anyInt());
+                        Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyInt());
 
         Mockito.doReturn(new ResultSetImpl<NodeSubscription>(subscriptions))
                 .when(channelManager).getNodeSubscriptionListeners(node);
@@ -431,7 +431,7 @@ public class ItemDeleteTest extends IQTestHandler {
         Mockito.when(channelManager.getNodeItem(node, "item-id")).thenReturn(
                 nodeItem);
         Mockito.when(channelManager.getNodeItemReplies(Mockito.eq(node), Mockito.eq("item-id"),
-                        Mockito.anyString(), Mockito.eq(-1))).thenReturn(new ClosableIteratorImpl<NodeItem>(replies
+                        Mockito.anyString(), Mockito.anyBoolean(), Mockito.eq(-1))).thenReturn(new ClosableIteratorImpl<NodeItem>(replies
                                 .iterator()));
 
         Mockito.doReturn(new ResultSetImpl<NodeSubscription>(subscriptions))


### PR DESCRIPTION
If `<before/>` is provided in RSM then we ignore `<after/>`