### PR TITLE
Improve actor validation.

### DIFF
--- a/src/test/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/PubSubSetTest.java
+++ b/src/test/java/org/buddycloud/channelserver/packetprocessor/iq/namespace/pubsub/PubSubSetTest.java
@@ -6,17 +6,14 @@ import junit.framework.Assert;
 
 import org.buddycloud.channelserver.channel.ChannelManager;
 import org.buddycloud.channelserver.packetHandler.iq.IQTestHandler;
-import org.buddycloud.channelserver.packetprocessor.iq.namespace.pubsub.get.AffiliationsGet;
 import org.buddycloud.channelserver.utils.XMLConstants;
 import org.buddycloud.channelserver.utils.node.item.payload.Buddycloud;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.xmpp.packet.IQ;
-import org.xmpp.packet.JID;
 import org.xmpp.packet.Packet;
 import org.xmpp.packet.PacketError;
-import org.xmpp.util.XMPPConstants;
 
 public class PubSubSetTest extends IQTestHandler {
 
@@ -31,15 +28,15 @@ public class PubSubSetTest extends IQTestHandler {
     pubsubSet = new PubSubSet(queue, channelManager);
     pubsubSet.purgeElementProcessors();
   }
-  
+
   @Test
   public void returnsErrorForIllegalActor() throws Exception {
     IQ request = readStanzaAsIq("/iq/pubsub/bad-actor.stanza");
-    
+
     pubsubSet.process(request);
     Assert.assertEquals(1, queue.size());
     IQ response = (IQ) queue.poll();
-    
+
     Assert.assertEquals(IQ.Type.error, response.getType());
 
     PacketError error = response.getError();
@@ -49,24 +46,45 @@ public class PubSubSetTest extends IQTestHandler {
     Assert.assertNotNull(response.getElement().element("error").element(XMLConstants.POLICY_VIOLATION));
     Assert.assertEquals(XMLConstants.INVALID_NODE, error.getApplicationConditionName());
     Assert.assertEquals(Buddycloud.NS_ERROR, error.getApplicationConditionNamespaceURI());
-    
+
+  }
+
+  @Test
+  public void returnsErrorForSpoofActor() throws Exception {
+    IQ request = readStanzaAsIq("/iq/pubsub/spoof-actor.stanza");
+
+    pubsubSet.process(request);
+    Assert.assertEquals(1, queue.size());
+    IQ response = (IQ) queue.poll();
+
+    Assert.assertEquals(IQ.Type.error, response.getType());
+
+    PacketError error = response.getError();
+    Assert.assertNotNull(error);
+
+    Assert.assertEquals(PacketError.Type.cancel, error.getType());
+    Assert.assertNotNull(response.getElement().element("error")
+        .element(XMLConstants.POLICY_VIOLATION));
+    Assert.assertEquals(XMLConstants.INVALID_NODE, error.getApplicationConditionName());
+    Assert.assertEquals(Buddycloud.NS_ERROR, error.getApplicationConditionNamespaceURI());
+
   }
 
   @Test
   public void ifPacketCanNotBeProcessedShouldReceiveAFeatureNotImplementedError() throws Exception {
     IQ request = readStanzaAsIq("/iq/pubsub/good-actor.stanza");
-    
+
     pubsubSet.process(request);
     Assert.assertEquals(1, queue.size());
     IQ response = (IQ) queue.poll();
-    
+
     Assert.assertEquals(IQ.Type.error, response.getType());
-  
+
     PacketError error = response.getError();
     Assert.assertNotNull(error);
-  
+
     Assert.assertEquals(PacketError.Type.cancel, error.getType());
     Assert.assertEquals(PacketError.Condition.feature_not_implemented, error.getCondition());
   }
-  
+
 }

--- a/src/test/resources/stanzas/iq/pubsub/spoof-actor.stanza
+++ b/src/test/resources/stanzas/iq/pubsub/spoof-actor.stanza
@@ -1,0 +1,9 @@
+<iq type="get"
+    from="channels.not-denmark.lit"
+    to="channels.shakespeare.lit"
+    id="items1">
+   <pubsub xmlns="http://jabber.org/protocol/pubsub">
+      <items node="/user/francisco@denmark.lit/posts"/>
+      <actor xmlns="http://buddycloud.org/v1">francisco@denmark.lit</actor>
+   </pubsub>
+</iq>


### PR DESCRIPTION
* previous mechanism compared the end of the sender's domain with the
  actor's domain. This allowed a sender at notdomain.com to act as any user
  from domain.com or main.com etc.
* Now compares the end of the sender's domain with the actor's domain
  prepended with a '.', this mean only a sender at a subdomain of the
  actor's registerd domain can act as them i.e. a component registered
  to the xmpp server.
* Renamed getActor method to validateActor as it was not a conventional
  getter.